### PR TITLE
Cocoa: Add custom document icons for supported filetypes

### DIFF
--- a/platforms/osx/milkytracker_cocoa/Info.plist
+++ b/platforms/osx/milkytracker_cocoa/Info.plist
@@ -7,6 +7,8 @@
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Protracker-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>MOD</string>
@@ -28,6 +30,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Ultratracker-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>ULT</string>
@@ -41,6 +45,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-PolyTracker-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>PTM</string>
@@ -54,6 +60,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Cubic-Tiny-XM-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>MXM</string>
@@ -67,6 +75,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Fasttracker-2-Extended-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>XM</string>
@@ -84,6 +94,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Disorder_Tracker-2-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>PLM</string>
@@ -97,6 +109,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Game-Music-Creator-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>GMC</string>
@@ -114,6 +128,8 @@
 			<string>Binary</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Digibooster-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>DIGI</string>
@@ -131,6 +147,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Digibooster-Pro-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>DBM</string>
@@ -144,6 +162,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Velvet-Studio-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>AMS</string>
@@ -161,6 +181,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Digitracker-3.0-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>MDL</string>
@@ -174,6 +196,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Multitracker-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>MTM</string>
@@ -187,6 +211,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Epic-Megagames-MASI-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>PSM</string>
@@ -200,6 +226,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-ScreamTracker-3-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>S3M</string>
@@ -213,6 +241,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-ScreamTracker-2-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>STM</string>
@@ -226,6 +256,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Imago-Orpheus-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>IMF</string>
@@ -239,6 +271,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Oktalyzer-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>OKT</string>
@@ -254,6 +288,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-MikMod-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>UNI</string>
@@ -267,6 +303,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Digital-Tracker-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>DTM</string>
@@ -280,6 +318,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Asylum-Music-Format-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>AMF</string>
@@ -293,6 +333,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Digisound-Interface-Kit-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>DSM</string>
@@ -306,6 +348,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-General-Digimusic-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>GDM</string>
@@ -319,6 +363,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Farandole-Composer-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>FAR</string>
@@ -332,6 +378,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Impulse-Tracker-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>IT</string>
@@ -349,6 +397,8 @@
 			<string>Binary</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Composer-669-Module</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>669</string>
@@ -361,6 +411,8 @@
 			<string>Music</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Fasttracker-2-Extended-Instrument</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>XI</string>
@@ -374,6 +426,8 @@
 			<string>Instrument</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Gravis-Ultrasound-Patch</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>PAT</string>
@@ -387,6 +441,8 @@
 			<string>Instrument</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-8SVX-Sample</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>8SVX</string>
@@ -404,6 +460,8 @@
 			<string>Binary</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-8SVX-Sample-IFF</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>IFF</string>
@@ -417,6 +475,8 @@
 			<string>Sample</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-WAV-Sample</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>WAV</string>
@@ -430,6 +490,8 @@
 			<string>Sample</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Fasttracker-2-Extended-Pattern</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>XP</string>
@@ -443,6 +505,8 @@
 			<string>Pattern</string>
 		</dict>
 		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>MilkyTracker-Fasttracker-2-Extended-Track</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>XT</string>

--- a/platforms/osx/milkytracker_cocoa/milkytracker_cocoa.xcodeproj/project.pbxproj
+++ b/platforms/osx/milkytracker_cocoa/milkytracker_cocoa.xcodeproj/project.pbxproj
@@ -243,6 +243,38 @@
 		2D5B404A1A07EC7500834B02 /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D5B3F0E1A07C92900834B02 /* AppDelegate.mm */; };
 		2D5B404B1A07EC7800834B02 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D5B3F3C1A07CA0400834B02 /* main.mm */; };
 		2D5B40541A08143000834B02 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D5B40531A08143000834B02 /* OpenGL.framework */; };
+		2D840BC11B640F8800717DD6 /* MilkyTracker-8SVX-Sample-IFF.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BA11B640F8800717DD6 /* MilkyTracker-8SVX-Sample-IFF.icns */; };
+		2D840BC21B640F8800717DD6 /* MilkyTracker-8SVX-Sample.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BA21B640F8800717DD6 /* MilkyTracker-8SVX-Sample.icns */; };
+		2D840BC31B640F8800717DD6 /* MilkyTracker-Asylum-Music-Format-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BA31B640F8800717DD6 /* MilkyTracker-Asylum-Music-Format-Module.icns */; };
+		2D840BC41B640F8800717DD6 /* MilkyTracker-Composer-669-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BA41B640F8800717DD6 /* MilkyTracker-Composer-669-Module.icns */; };
+		2D840BC51B640F8800717DD6 /* MilkyTracker-Cubic-Tiny-XM-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BA51B640F8800717DD6 /* MilkyTracker-Cubic-Tiny-XM-Module.icns */; };
+		2D840BC61B640F8800717DD6 /* MilkyTracker-Digibooster-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BA61B640F8800717DD6 /* MilkyTracker-Digibooster-Module.icns */; };
+		2D840BC71B640F8800717DD6 /* MilkyTracker-Digibooster-Pro-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BA71B640F8800717DD6 /* MilkyTracker-Digibooster-Pro-Module.icns */; };
+		2D840BC81B640F8800717DD6 /* MilkyTracker-Digisound-Interface-Kit-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BA81B640F8800717DD6 /* MilkyTracker-Digisound-Interface-Kit-Module.icns */; };
+		2D840BC91B640F8800717DD6 /* MilkyTracker-Digital-Tracker-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BA91B640F8800717DD6 /* MilkyTracker-Digital-Tracker-Module.icns */; };
+		2D840BCA1B640F8800717DD6 /* MilkyTracker-Digitracker-3.0-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BAA1B640F8800717DD6 /* MilkyTracker-Digitracker-3.0-Module.icns */; };
+		2D840BCB1B640F8800717DD6 /* MilkyTracker-Disorder_Tracker-2-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BAB1B640F8800717DD6 /* MilkyTracker-Disorder_Tracker-2-Module.icns */; };
+		2D840BCC1B640F8800717DD6 /* MilkyTracker-Epic-Megagames-MASI-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BAC1B640F8800717DD6 /* MilkyTracker-Epic-Megagames-MASI-Module.icns */; };
+		2D840BCD1B640F8800717DD6 /* MilkyTracker-Farandole-Composer-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BAD1B640F8800717DD6 /* MilkyTracker-Farandole-Composer-Module.icns */; };
+		2D840BCE1B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Instrument.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BAE1B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Instrument.icns */; };
+		2D840BCF1B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BAF1B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Module.icns */; };
+		2D840BD01B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Pattern.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BB01B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Pattern.icns */; };
+		2D840BD11B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Track.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BB11B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Track.icns */; };
+		2D840BD21B640F8800717DD6 /* MilkyTracker-Game-Music-Creator-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BB21B640F8800717DD6 /* MilkyTracker-Game-Music-Creator-Module.icns */; };
+		2D840BD31B640F8800717DD6 /* MilkyTracker-General-Digimusic-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BB31B640F8800717DD6 /* MilkyTracker-General-Digimusic-Module.icns */; };
+		2D840BD41B640F8800717DD6 /* MilkyTracker-Gravis-Ultrasound-Patch.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BB41B640F8800717DD6 /* MilkyTracker-Gravis-Ultrasound-Patch.icns */; };
+		2D840BD51B640F8800717DD6 /* MilkyTracker-Imago-Orpheus-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BB51B640F8800717DD6 /* MilkyTracker-Imago-Orpheus-Module.icns */; };
+		2D840BD61B640F8800717DD6 /* MilkyTracker-Impulse-Tracker-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BB61B640F8800717DD6 /* MilkyTracker-Impulse-Tracker-Module.icns */; };
+		2D840BD71B640F8800717DD6 /* MilkyTracker-MikMod-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BB71B640F8800717DD6 /* MilkyTracker-MikMod-Module.icns */; };
+		2D840BD81B640F8800717DD6 /* MilkyTracker-Multitracker-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BB81B640F8800717DD6 /* MilkyTracker-Multitracker-Module.icns */; };
+		2D840BD91B640F8800717DD6 /* MilkyTracker-Oktalyzer-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BB91B640F8800717DD6 /* MilkyTracker-Oktalyzer-Module.icns */; };
+		2D840BDA1B640F8800717DD6 /* MilkyTracker-PolyTracker-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BBA1B640F8800717DD6 /* MilkyTracker-PolyTracker-Module.icns */; };
+		2D840BDB1B640F8800717DD6 /* MilkyTracker-Protracker-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BBB1B640F8800717DD6 /* MilkyTracker-Protracker-Module.icns */; };
+		2D840BDC1B640F8800717DD6 /* MilkyTracker-ScreamTracker-2-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BBC1B640F8800717DD6 /* MilkyTracker-ScreamTracker-2-Module.icns */; };
+		2D840BDD1B640F8800717DD6 /* MilkyTracker-ScreamTracker-3-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BBD1B640F8800717DD6 /* MilkyTracker-ScreamTracker-3-Module.icns */; };
+		2D840BDE1B640F8800717DD6 /* MilkyTracker-Ultratracker-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BBE1B640F8800717DD6 /* MilkyTracker-Ultratracker-Module.icns */; };
+		2D840BDF1B640F8800717DD6 /* MilkyTracker-Velvet-Studio-Module.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BBF1B640F8800717DD6 /* MilkyTracker-Velvet-Studio-Module.icns */; };
+		2D840BE01B640F8800717DD6 /* MilkyTracker-WAV-Sample.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2D840BC01B640F8800717DD6 /* MilkyTracker-WAV-Sample.icns */; };
 		2DAC75091A210420004D52C9 /* DisplayDevice_COCOA.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DAC75071A210420004D52C9 /* DisplayDevice_COCOA.mm */; };
 		2DB910C41A313FB50062F0A0 /* PPMutex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2DB910C31A313FB50062F0A0 /* PPMutex.cpp */; };
 		2DB910C71A353D710062F0A0 /* MTKeyTranslator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DB910C61A353D710062F0A0 /* MTKeyTranslator.mm */; };
@@ -275,6 +307,38 @@
 		2D5B40431A07E4F900834B02 /* PPSavePanel_COCOA.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PPSavePanel_COCOA.mm; sourceTree = "<group>"; };
 		2D5B40481A07E63C00834B02 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		2D5B40531A08143000834B02 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		2D840BA11B640F8800717DD6 /* MilkyTracker-8SVX-Sample-IFF.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-8SVX-Sample-IFF.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-8SVX-Sample-IFF.icns"; sourceTree = "<group>"; };
+		2D840BA21B640F8800717DD6 /* MilkyTracker-8SVX-Sample.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-8SVX-Sample.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-8SVX-Sample.icns"; sourceTree = "<group>"; };
+		2D840BA31B640F8800717DD6 /* MilkyTracker-Asylum-Music-Format-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Asylum-Music-Format-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Asylum-Music-Format-Module.icns"; sourceTree = "<group>"; };
+		2D840BA41B640F8800717DD6 /* MilkyTracker-Composer-669-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Composer-669-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Composer-669-Module.icns"; sourceTree = "<group>"; };
+		2D840BA51B640F8800717DD6 /* MilkyTracker-Cubic-Tiny-XM-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Cubic-Tiny-XM-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Cubic-Tiny-XM-Module.icns"; sourceTree = "<group>"; };
+		2D840BA61B640F8800717DD6 /* MilkyTracker-Digibooster-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Digibooster-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Digibooster-Module.icns"; sourceTree = "<group>"; };
+		2D840BA71B640F8800717DD6 /* MilkyTracker-Digibooster-Pro-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Digibooster-Pro-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Digibooster-Pro-Module.icns"; sourceTree = "<group>"; };
+		2D840BA81B640F8800717DD6 /* MilkyTracker-Digisound-Interface-Kit-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Digisound-Interface-Kit-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Digisound-Interface-Kit-Module.icns"; sourceTree = "<group>"; };
+		2D840BA91B640F8800717DD6 /* MilkyTracker-Digital-Tracker-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Digital-Tracker-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Digital-Tracker-Module.icns"; sourceTree = "<group>"; };
+		2D840BAA1B640F8800717DD6 /* MilkyTracker-Digitracker-3.0-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Digitracker-3.0-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Digitracker-3.0-Module.icns"; sourceTree = "<group>"; };
+		2D840BAB1B640F8800717DD6 /* MilkyTracker-Disorder_Tracker-2-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Disorder_Tracker-2-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Disorder_Tracker-2-Module.icns"; sourceTree = "<group>"; };
+		2D840BAC1B640F8800717DD6 /* MilkyTracker-Epic-Megagames-MASI-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Epic-Megagames-MASI-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Epic-Megagames-MASI-Module.icns"; sourceTree = "<group>"; };
+		2D840BAD1B640F8800717DD6 /* MilkyTracker-Farandole-Composer-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Farandole-Composer-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Farandole-Composer-Module.icns"; sourceTree = "<group>"; };
+		2D840BAE1B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Instrument.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Fasttracker-2-Extended-Instrument.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Fasttracker-2-Extended-Instrument.icns"; sourceTree = "<group>"; };
+		2D840BAF1B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Fasttracker-2-Extended-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Fasttracker-2-Extended-Module.icns"; sourceTree = "<group>"; };
+		2D840BB01B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Pattern.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Fasttracker-2-Extended-Pattern.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Fasttracker-2-Extended-Pattern.icns"; sourceTree = "<group>"; };
+		2D840BB11B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Track.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Fasttracker-2-Extended-Track.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Fasttracker-2-Extended-Track.icns"; sourceTree = "<group>"; };
+		2D840BB21B640F8800717DD6 /* MilkyTracker-Game-Music-Creator-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Game-Music-Creator-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Game-Music-Creator-Module.icns"; sourceTree = "<group>"; };
+		2D840BB31B640F8800717DD6 /* MilkyTracker-General-Digimusic-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-General-Digimusic-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-General-Digimusic-Module.icns"; sourceTree = "<group>"; };
+		2D840BB41B640F8800717DD6 /* MilkyTracker-Gravis-Ultrasound-Patch.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Gravis-Ultrasound-Patch.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Gravis-Ultrasound-Patch.icns"; sourceTree = "<group>"; };
+		2D840BB51B640F8800717DD6 /* MilkyTracker-Imago-Orpheus-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Imago-Orpheus-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Imago-Orpheus-Module.icns"; sourceTree = "<group>"; };
+		2D840BB61B640F8800717DD6 /* MilkyTracker-Impulse-Tracker-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Impulse-Tracker-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Impulse-Tracker-Module.icns"; sourceTree = "<group>"; };
+		2D840BB71B640F8800717DD6 /* MilkyTracker-MikMod-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-MikMod-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-MikMod-Module.icns"; sourceTree = "<group>"; };
+		2D840BB81B640F8800717DD6 /* MilkyTracker-Multitracker-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Multitracker-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Multitracker-Module.icns"; sourceTree = "<group>"; };
+		2D840BB91B640F8800717DD6 /* MilkyTracker-Oktalyzer-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Oktalyzer-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Oktalyzer-Module.icns"; sourceTree = "<group>"; };
+		2D840BBA1B640F8800717DD6 /* MilkyTracker-PolyTracker-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-PolyTracker-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-PolyTracker-Module.icns"; sourceTree = "<group>"; };
+		2D840BBB1B640F8800717DD6 /* MilkyTracker-Protracker-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Protracker-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Protracker-Module.icns"; sourceTree = "<group>"; };
+		2D840BBC1B640F8800717DD6 /* MilkyTracker-ScreamTracker-2-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-ScreamTracker-2-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-ScreamTracker-2-Module.icns"; sourceTree = "<group>"; };
+		2D840BBD1B640F8800717DD6 /* MilkyTracker-ScreamTracker-3-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-ScreamTracker-3-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-ScreamTracker-3-Module.icns"; sourceTree = "<group>"; };
+		2D840BBE1B640F8800717DD6 /* MilkyTracker-Ultratracker-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Ultratracker-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Ultratracker-Module.icns"; sourceTree = "<group>"; };
+		2D840BBF1B640F8800717DD6 /* MilkyTracker-Velvet-Studio-Module.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-Velvet-Studio-Module.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-Velvet-Studio-Module.icns"; sourceTree = "<group>"; };
+		2D840BC01B640F8800717DD6 /* MilkyTracker-WAV-Sample.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = "MilkyTracker-WAV-Sample.icns"; path = "../../../resources/pictures/docicons/osx/MilkyTracker-WAV-Sample.icns"; sourceTree = "<group>"; };
 		2DAC75071A210420004D52C9 /* DisplayDevice_COCOA.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DisplayDevice_COCOA.mm; sourceTree = "<group>"; };
 		2DAC75081A210420004D52C9 /* DisplayDevice_COCOA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisplayDevice_COCOA.h; sourceTree = "<group>"; };
 		2DB910C31A313FB50062F0A0 /* PPMutex.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PPMutex.cpp; sourceTree = "<group>"; };
@@ -771,6 +835,7 @@
 		2D5B3F091A07132900834B02 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				2D840BA01B63FD8600717DD6 /* Document Icons */,
 				2D5B3F071A07131E00834B02 /* carton.icns */,
 				2D5B3EFD1A070DEB00834B02 /* Info.plist */,
 			);
@@ -809,6 +874,45 @@
 				2D5B40431A07E4F900834B02 /* PPSavePanel_COCOA.mm */,
 			);
 			path = cocoa;
+			sourceTree = "<group>";
+		};
+		2D840BA01B63FD8600717DD6 /* Document Icons */ = {
+			isa = PBXGroup;
+			children = (
+				2D840BA11B640F8800717DD6 /* MilkyTracker-8SVX-Sample-IFF.icns */,
+				2D840BA21B640F8800717DD6 /* MilkyTracker-8SVX-Sample.icns */,
+				2D840BA31B640F8800717DD6 /* MilkyTracker-Asylum-Music-Format-Module.icns */,
+				2D840BA41B640F8800717DD6 /* MilkyTracker-Composer-669-Module.icns */,
+				2D840BA51B640F8800717DD6 /* MilkyTracker-Cubic-Tiny-XM-Module.icns */,
+				2D840BA61B640F8800717DD6 /* MilkyTracker-Digibooster-Module.icns */,
+				2D840BA71B640F8800717DD6 /* MilkyTracker-Digibooster-Pro-Module.icns */,
+				2D840BA81B640F8800717DD6 /* MilkyTracker-Digisound-Interface-Kit-Module.icns */,
+				2D840BA91B640F8800717DD6 /* MilkyTracker-Digital-Tracker-Module.icns */,
+				2D840BAA1B640F8800717DD6 /* MilkyTracker-Digitracker-3.0-Module.icns */,
+				2D840BAB1B640F8800717DD6 /* MilkyTracker-Disorder_Tracker-2-Module.icns */,
+				2D840BAC1B640F8800717DD6 /* MilkyTracker-Epic-Megagames-MASI-Module.icns */,
+				2D840BAD1B640F8800717DD6 /* MilkyTracker-Farandole-Composer-Module.icns */,
+				2D840BAE1B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Instrument.icns */,
+				2D840BAF1B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Module.icns */,
+				2D840BB01B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Pattern.icns */,
+				2D840BB11B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Track.icns */,
+				2D840BB21B640F8800717DD6 /* MilkyTracker-Game-Music-Creator-Module.icns */,
+				2D840BB31B640F8800717DD6 /* MilkyTracker-General-Digimusic-Module.icns */,
+				2D840BB41B640F8800717DD6 /* MilkyTracker-Gravis-Ultrasound-Patch.icns */,
+				2D840BB51B640F8800717DD6 /* MilkyTracker-Imago-Orpheus-Module.icns */,
+				2D840BB61B640F8800717DD6 /* MilkyTracker-Impulse-Tracker-Module.icns */,
+				2D840BB71B640F8800717DD6 /* MilkyTracker-MikMod-Module.icns */,
+				2D840BB81B640F8800717DD6 /* MilkyTracker-Multitracker-Module.icns */,
+				2D840BB91B640F8800717DD6 /* MilkyTracker-Oktalyzer-Module.icns */,
+				2D840BBA1B640F8800717DD6 /* MilkyTracker-PolyTracker-Module.icns */,
+				2D840BBB1B640F8800717DD6 /* MilkyTracker-Protracker-Module.icns */,
+				2D840BBC1B640F8800717DD6 /* MilkyTracker-ScreamTracker-2-Module.icns */,
+				2D840BBD1B640F8800717DD6 /* MilkyTracker-ScreamTracker-3-Module.icns */,
+				2D840BBE1B640F8800717DD6 /* MilkyTracker-Ultratracker-Module.icns */,
+				2D840BBF1B640F8800717DD6 /* MilkyTracker-Velvet-Studio-Module.icns */,
+				2D840BC01B640F8800717DD6 /* MilkyTracker-WAV-Sample.icns */,
+			);
+			name = "Document Icons";
 			sourceTree = "<group>";
 		};
 		2DAC75061A210420004D52C9 /* cocoa */ = {
@@ -1491,8 +1595,40 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2D840BD51B640F8800717DD6 /* MilkyTracker-Imago-Orpheus-Module.icns in Resources */,
+				2D840BD91B640F8800717DD6 /* MilkyTracker-Oktalyzer-Module.icns in Resources */,
+				2D840BC91B640F8800717DD6 /* MilkyTracker-Digital-Tracker-Module.icns in Resources */,
+				2D840BE01B640F8800717DD6 /* MilkyTracker-WAV-Sample.icns in Resources */,
 				2D5B40361A07D4F500834B02 /* Application.xib in Resources */,
+				2D840BD41B640F8800717DD6 /* MilkyTracker-Gravis-Ultrasound-Patch.icns in Resources */,
+				2D840BDA1B640F8800717DD6 /* MilkyTracker-PolyTracker-Module.icns in Resources */,
+				2D840BDE1B640F8800717DD6 /* MilkyTracker-Ultratracker-Module.icns in Resources */,
+				2D840BC11B640F8800717DD6 /* MilkyTracker-8SVX-Sample-IFF.icns in Resources */,
+				2D840BCC1B640F8800717DD6 /* MilkyTracker-Epic-Megagames-MASI-Module.icns in Resources */,
+				2D840BD71B640F8800717DD6 /* MilkyTracker-MikMod-Module.icns in Resources */,
+				2D840BD01B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Pattern.icns in Resources */,
+				2D840BCF1B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Module.icns in Resources */,
+				2D840BC71B640F8800717DD6 /* MilkyTracker-Digibooster-Pro-Module.icns in Resources */,
+				2D840BCA1B640F8800717DD6 /* MilkyTracker-Digitracker-3.0-Module.icns in Resources */,
+				2D840BC41B640F8800717DD6 /* MilkyTracker-Composer-669-Module.icns in Resources */,
+				2D840BDF1B640F8800717DD6 /* MilkyTracker-Velvet-Studio-Module.icns in Resources */,
+				2D840BDD1B640F8800717DD6 /* MilkyTracker-ScreamTracker-3-Module.icns in Resources */,
 				2D5B40371A07D4F500834B02 /* carton.icns in Resources */,
+				2D840BD31B640F8800717DD6 /* MilkyTracker-General-Digimusic-Module.icns in Resources */,
+				2D840BC61B640F8800717DD6 /* MilkyTracker-Digibooster-Module.icns in Resources */,
+				2D840BDC1B640F8800717DD6 /* MilkyTracker-ScreamTracker-2-Module.icns in Resources */,
+				2D840BC81B640F8800717DD6 /* MilkyTracker-Digisound-Interface-Kit-Module.icns in Resources */,
+				2D840BDB1B640F8800717DD6 /* MilkyTracker-Protracker-Module.icns in Resources */,
+				2D840BCE1B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Instrument.icns in Resources */,
+				2D840BD81B640F8800717DD6 /* MilkyTracker-Multitracker-Module.icns in Resources */,
+				2D840BC51B640F8800717DD6 /* MilkyTracker-Cubic-Tiny-XM-Module.icns in Resources */,
+				2D840BC21B640F8800717DD6 /* MilkyTracker-8SVX-Sample.icns in Resources */,
+				2D840BD11B640F8800717DD6 /* MilkyTracker-Fasttracker-2-Extended-Track.icns in Resources */,
+				2D840BCD1B640F8800717DD6 /* MilkyTracker-Farandole-Composer-Module.icns in Resources */,
+				2D840BD21B640F8800717DD6 /* MilkyTracker-Game-Music-Creator-Module.icns in Resources */,
+				2D840BD61B640F8800717DD6 /* MilkyTracker-Impulse-Tracker-Module.icns in Resources */,
+				2D840BC31B640F8800717DD6 /* MilkyTracker-Asylum-Music-Format-Module.icns in Resources */,
+				2D840BCB1B640F8800717DD6 /* MilkyTracker-Disorder_Tracker-2-Module.icns in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/resources/pictures/docicons/osx/genicons.py
+++ b/resources/pictures/docicons/osx/genicons.py
@@ -1,0 +1,108 @@
+#
+# genicons.py
+#
+# MilkyTracker document icons generation script for OSX
+# Dale Whinham 25/7/2015
+#
+# To run this script you will need Python 2.7 and PyObjC, which should both be included with Mac OS X.
+#
+# If you have upgraded Python using homebrew or similar and are missing PyObjC, install it like so:
+#     $ pip install -U pyobjc-core
+#     $ pip install -U pyobjc
+#
+# You will also need Docerator 2.0. Download and unzip it to a directory called 'docerator' in the same directory as this script.
+#     $ wget https://docerator.googlecode.com/files/docerator-2.0.zip
+#     $ unzip docerator-2.0.zip -d docerator
+#     $ rm docerator-2.0.zip
+
+from os import listdir, remove, path
+from shutil import rmtree
+from subprocess import call
+import sys
+
+DOCERATOR_PATH = "docerator"
+APPICON_PATH = "../../carton.png"
+MAKEICNS_PATH = "docerator/makeicns"
+SYS_DOCICON_PATH = "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericDocumentIcon.icns"
+ICONSET_DIR = "GenericDocumentIcon.iconset"
+ICNS_FILE = "GenericDocumentIcon.icns"
+
+# Add docerator's folder to the system path so we can import it from another folder
+sys.path.append(DOCERATOR_PATH)
+import docerator
+
+# Rects calculated by running flow (included with Docerator) on a template designed in a graphics editor (I used Pixelmator).
+# The template is the OSX document icon with the 'carton' pasted on top as follows:
+# 128x128: Centred horizontally, translated 33px from bottom edge, 60% scale.
+# 256x256: Centred horizontally, translated 66px from bottom edge, 120% scale.
+# 512x512: Centred horizontally, translated 132px from bottom edge, 240% scale.
+RECTS = {
+	128: (1.4138, 0.5835, -7.3221, 0.5953),
+	256: (2.4603, 0.5952, -14.6274, 0.5975),
+	512: (5.9676, 0.5970, -29.7340, 0.6000)
+}
+
+# Dictionary of file types and their extensions
+FILETYPES = {
+	'MilkyTracker-Protracker-Module': 'MOD',
+	'MilkyTracker-Ultratracker-Module': 'ULT',
+	'MilkyTracker-PolyTracker-Module': 'PTM',
+	'MilkyTracker-Cubic-Tiny-XM-Module': 'MXM',
+	'MilkyTracker-Fasttracker-2-Extended-Module': 'XM',
+	'MilkyTracker-Disorder_Tracker-2-Module': 'PLM',
+	'MilkyTracker-Game-Music-Creator-Module': 'GMC',
+	'MilkyTracker-Digibooster-Module': 'DIGI',
+	'MilkyTracker-Digibooster-Pro-Module': 'DBM',
+	'MilkyTracker-Velvet-Studio-Module': 'AMS',
+	'MilkyTracker-Digitracker-3.0-Module': 'MDL',
+	'MilkyTracker-Multitracker-Module': 'MTM',
+	'MilkyTracker-Epic-Megagames-MASI-Module': 'PSM',
+	'MilkyTracker-ScreamTracker-3-Module': 'S3M',
+	'MilkyTracker-ScreamTracker-2-Module': 'STM',
+	'MilkyTracker-Imago-Orpheus-Module': 'IMF',
+	'MilkyTracker-Oktalyzer-Module': 'OKT',
+	'MilkyTracker-MikMod-Module': 'UNI',
+	'MilkyTracker-Digital-Tracker-Module': 'DTM',
+	'MilkyTracker-Asylum-Music-Format-Module': 'AMF',
+	'MilkyTracker-Digisound-Interface-Kit-Module': 'DSM',
+	'MilkyTracker-General-Digimusic-Module': 'GDM',
+	'MilkyTracker-Farandole-Composer-Module': 'FAR',
+	'MilkyTracker-Impulse-Tracker-Module': 'IT',
+	'MilkyTracker-Composer-669-Module': '669',
+	'MilkyTracker-Fasttracker-2-Extended-Instrument': 'XI',
+	'MilkyTracker-Gravis-Ultrasound-Patch': 'PAT',
+	'MilkyTracker-8SVX-Sample': '8SVX',
+	'MilkyTracker-8SVX-Sample-IFF': 'IFF',
+	'MilkyTracker-WAV-Sample': 'WAV',
+	'MilkyTracker-Fasttracker-2-Extended-Pattern': 'XP',
+	'MilkyTracker-Fasttracker-2-Extended-Track': 'XT'
+}
+
+# Get system document icns file and extract individual sizes
+call(["iconutil", "-c", "iconset", "-o", ICONSET_DIR, SYS_DOCICON_PATH])
+
+# Remove Mavericks-onwards high-resolution '2x' variants, as Docerator currently cannot handle them
+for f in listdir(ICONSET_DIR):
+	if "@2x" in f:
+		remove(path.join(ICONSET_DIR, f))
+
+# Rebuild local copy of .icns file without '2x' variants
+call(["iconutil", "-c", "icns", "-o", ICNS_FILE, ICONSET_DIR])
+
+# Remove previously extracted icons
+rmtree(ICONSET_DIR)
+
+# Generate document icons
+for name, extension in FILETYPES.iteritems():
+	print(name)
+	docerator.makedocicon(	outname='%s.icns' % name,
+							appicon=APPICON_PATH,
+							text=extension,
+							sizes=[512, 256, 128, 32, 16],
+							makeicns=MAKEICNS_PATH,
+							background=ICNS_FILE,
+							rects=RECTS
+	)
+
+# Clean up temporary document background file
+remove(ICNS_FILE)


### PR DESCRIPTION
A Python script in resources/pictures/docicons/osx called 'genicons.py' must be run to generate the icons before building the Cocoa project with Xcode.
See script comments for instructions/requirements.